### PR TITLE
Modified the starting treachery deck to properly include the Harkonnen Extra card

### DIFF
--- a/Shared/Game_Setup.cs
+++ b/Shared/Game_Setup.cs
@@ -20,7 +20,6 @@ public partial class Game
     internal Phase PhaseBeforeSkillAssignment { get; set; }
     public Faction NextFactionToPerformCustomSetup => Players.Select(p => p.Faction).FirstOrDefault(f => !HasActedOrPassed.Contains(f));
     public Deck<TreacheryCard> StartingTreacheryCards { get; private set; }
-    private TreacheryCard ExtraStartingCardForBlack { get; set; }
 
     #endregion State
 
@@ -339,7 +338,7 @@ public partial class Game
         {
             StartingTreacheryCards.Items.Add(TreacheryDeck.Draw());
 
-            if (p.Is(Faction.Black)) ExtraStartingCardForBlack = TreacheryDeck.Draw();
+            if (p.Is(Faction.Black)) StartingTreacheryCards.Items.Add(TreacheryDeck.Draw());
         }
 
         Enter(IsPlaying(Faction.Grey), Phase.GreySelectingCard, DealRemainingStartingTreacheryCardsToNonGrey);
@@ -355,8 +354,9 @@ public partial class Game
 
             if (p.Is(Faction.Black))
             {
-                p.TreacheryCards.Add(ExtraStartingCardForBlack);
-                LogTo(Faction.Black, "Your extra card is: ", ExtraStartingCardForBlack);
+                var extraCard = StartingTreacheryCards.Draw();
+                p.TreacheryCards.Add(extraCard);
+                LogTo(Faction.Black, "Your extra card is: ", extraCard);
             }
         }
 


### PR DESCRIPTION
The IX now properly see the aditionall starting card from Harkonen. The ExtraStartingCardForBlack variable is removed, and instead an additional card is added to the initial starting deck, and later removed by Black.