### PR TITLE
Fix to issue #92

### DIFF
--- a/Shared/Events/KarmaBrownDiscard.cs
+++ b/Shared/Events/KarmaBrownDiscard.cs
@@ -43,8 +43,16 @@ public class KarmaBrownDiscard : GameEvent
     public override Message Validate()
     {
         var karmaCardToUse = Player.TreacheryCards.FirstOrDefault(c => c.Type == TreacheryCardType.Karma);
-        if (karmaCardToUse == null) return Message.Express("You don't have a ", TreacheryCardType.Karma, " card");
-        if (Cards.Contains(karmaCardToUse)) return Message.Express("You can't select the ", TreacheryCardType.Karma, " you need to play to use this power");
+        
+        var clairvoyanceToUse = Player.TreacheryCards.FirstOrDefault(c => c.Type == TreacheryCardType.Clairvoyance);
+
+        if (!Player.Occupies(Game.Map.Shrine)) clairvoyanceToUse = null;
+            
+        if (karmaCardToUse == null && clairvoyanceToUse == null) return Message.Express("You don't have a ", TreacheryCardType.Karma, " card");
+        
+        
+        if (Cards.Contains(karmaCardToUse) && Cards.Contains(clairvoyanceToUse)) return Message.Express(
+            "You can't select the ", TreacheryCardType.Karma, " you need to play to use this power");
 
         return null;
     }


### PR DESCRIPTION
Validate now checks to find a clairvoyance card and if the player occupies the shrine, allows them to use that as their karama source. Additionally, the function now checks that there is at least 1 remaining karma source that is not being discarded with the karama ability.

Cards.Contains *should* handle the value being null and simply return false, if that is not the case, this fix will not work.