### PR TITLE
Add house rule to break all alliances at start of alliance phase

### DIFF
--- a/Server/Data/TreacheryContext.cs
+++ b/Server/Data/TreacheryContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 
 namespace Treachery.Server;
@@ -15,5 +16,6 @@ public partial class TreacheryContext(DbContextOptions<TreacheryContext> options
     {
         var connectionString = configuration.GetConnectionString("TreacheryDatabase");
         optionsBuilder.UseSqlite(connectionString);
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
     }
 }

--- a/Server/Data/TreacheryContext.cs
+++ b/Server/Data/TreacheryContext.cs
@@ -16,6 +16,5 @@ public partial class TreacheryContext(DbContextOptions<TreacheryContext> options
     {
         var connectionString = configuration.GetConnectionString("TreacheryDatabase");
         optionsBuilder.UseSqlite(connectionString);
-        optionsBuilder.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
     }
 }

--- a/Shared/Enumerations.cs
+++ b/Shared/Enumerations.cs
@@ -635,6 +635,7 @@ public enum Rule
     AssistedNotekeepingForGreen = 117,
     YellowAllyGetsDialedResourcesRefunded = 118,
     DisableNovaFlipping = 119,
+    BreakAlliancesOnAlliancePhase = 120,
 
     ExtraKaramaCards = 999,
 

--- a/Shared/Events/NexusVoted.cs
+++ b/Shared/Events/NexusVoted.cs
@@ -43,7 +43,10 @@ public class NexusVoted : PassableGameEvent
             if (2 * Game.NexusVotes.Count(v => v.Passed) >= Game.Players.Count)
                 Game.Enter(Game.CurrentPhase == Phase.VoteAllianceA && Game.Applicable(Rule.IncreasedResourceFlow), Game.EnterBlowB, Game.StartNexusCardPhase);
             else
+            {
+                if (Game.Applicable(Rule.BreakAlliancesOnAlliancePhase)) Game.BreakAllAlliances();
                 Game.Enter(Game.CurrentPhase == Phase.VoteAllianceA, Phase.AllianceA, Phase.AllianceB);
+            }
         }
     }
 

--- a/Shared/Game_Alliances.cs
+++ b/Shared/Game_Alliances.cs
@@ -63,6 +63,16 @@ public partial class Game
         while (playerB.HandSizeExceeded) Discard(playerB, playerB.TreacheryCards.RandomOrDefault(Random));
     }
 
+    internal void BreakAllAlliances()
+    {
+        foreach (var p in Players.Where(p => p.HasAlly).ToList())
+            if (p.HasAlly)
+            {
+                Log(p.Faction, " and ", p.Ally, " alliance is broken");
+                BreakAlliance(p.Faction);
+            }
+    }
+
     internal void BreakAlliance(Faction f)
     {
         var initiator = GetPlayer(f);

--- a/Shared/Game_Blow.cs
+++ b/Shared/Game_Blow.cs
@@ -237,6 +237,8 @@ public partial class Game
         {
             CurrentAllianceOffers.Clear();
 
+            if (Applicable(Rule.BreakAlliancesOnAlliancePhase)) BreakAllAlliances();
+
             if (Monsters.Count == 1 && Monsters[0].IsGreatMonster)
             {
                 NexusVotes.Clear();

--- a/Shared/Game_Rules.cs
+++ b/Shared/Game_Rules.cs
@@ -336,7 +336,8 @@ public partial class Game
             or Rule.AssistedNotekeeping or Rule.AssistedNotekeepingForGreen or Rule.ResourceBonusForStrongholds
             or Rule.BattleWithoutLeader or Rule.CapturedLeadersAreTraitorsToOwnFaction
             or Rule.DisableEndOfGameReport or Rule.DisableOrangeSpecialVictory or Rule.DisableResourceTransfers
-            or Rule.DisableNovaFlipping or Rule.YellowAllyGetsDialedResourcesRefunded => RuleGroup.House,
+            or Rule.DisableNovaFlipping or Rule.YellowAllyGetsDialedResourcesRefunded
+            or Rule.BreakAlliancesOnAlliancePhase => RuleGroup.House,
         Rule.BotsCannotAlly => RuleGroup.Bots,
         Rule.TechTokens or Rule.CheapHeroTraitor or Rule.ExpansionTreacheryCards or Rule.SandTrout => RuleGroup
             .ExpansionIxAndBtBasic,
@@ -379,7 +380,8 @@ public partial class Game
                 or Rule.AssistedNotekeeping or Rule.AssistedNotekeepingForGreen or Rule.ResourceBonusForStrongholds
                 or Rule.BattleWithoutLeader or Rule.CapturedLeadersAreTraitorsToOwnFaction
                 or Rule.DisableEndOfGameReport or Rule.DisableOrangeSpecialVictory or Rule.DisableResourceTransfers
-                or Rule.YellowAllyGetsDialedResourcesRefunded or Rule.DisableNovaFlipping => 0,
+                or Rule.YellowAllyGetsDialedResourcesRefunded or Rule.DisableNovaFlipping
+                or Rule.BreakAlliancesOnAlliancePhase => 0,
             Rule.FillWithBots or Rule.BotsCannotAlly => 0,
             Rule.TechTokens or Rule.CheapHeroTraitor or Rule.ExpansionTreacheryCards or Rule.SandTrout => 1,
             Rule.GreySwappingCardOnBid or Rule.PurpleGholas => 1,

--- a/Shared/Model/Skin.cs
+++ b/Shared/Model/Skin.cs
@@ -911,7 +911,7 @@ public class Skin : IDescriber
             Rule.DisableOrangeSpecialVictory => Format("Disable {0} special victory condition", Faction.Orange),
             Rule.DisableResourceTransfers => Format("Only allow transfer of {0} by alliance rules", Concept.Resource),
             Rule.YellowAllyGetsDialedResourcesRefunded => Format("{0} ally may get {1} dialled in battles refunded in {2} phase", Faction.Yellow, Concept.Resource, MainPhase.Contemplate),
-            Rule.BreakAlliancesOnAlliancePhase => "All alliances are automatically broken at the start of each alliance phase",
+            Rule.BreakAlliancesOnAlliancePhase => "Alliances are  broken at the start of each alliance phase",
 
             _ => "unknown rule"
         };

--- a/Shared/Model/Skin.cs
+++ b/Shared/Model/Skin.cs
@@ -911,6 +911,7 @@ public class Skin : IDescriber
             Rule.DisableOrangeSpecialVictory => Format("Disable {0} special victory condition", Faction.Orange),
             Rule.DisableResourceTransfers => Format("Only allow transfer of {0} by alliance rules", Concept.Resource),
             Rule.YellowAllyGetsDialedResourcesRefunded => Format("{0} ally may get {1} dialled in battles refunded in {2} phase", Faction.Yellow, Concept.Resource, MainPhase.Contemplate),
+            Rule.BreakAlliancesOnAlliancePhase => "All alliances are automatically broken at the start of each alliance phase",
 
             _ => "unknown rule"
         };


### PR DESCRIPTION
Starting with alliances broken at the beginning of the alliance phase creates more likelihood for alliance shifts which is more in-line with the way over the board discussion go as people shufle alliances.

By front-loading alliance breaks, the phase can be more fair. Players are often reluctant to break alliances even in situations where they would not re-up that alliance. This forces players to come to the negotiation table, leading to more negotiation and strategy.