### PR TITLE
Add redo UI and restore/dismiss actions - Fixes Issue #127

### DIFF
--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -136,6 +136,8 @@ public class Client : IGameService, IGameClient, IAsyncDisposable
         _connection.On<int>(nameof(HandleSetTimer), HandleSetTimer);
         _connection.On<string>(nameof(HandleSetSkin), HandleSetSkin);
         _connection.On<int>(nameof(HandleUndo), HandleUndo);
+        _connection.On(nameof(HandleRestoreRecentlyUndone), HandleRestoreRecentlyUndone);
+        _connection.On(nameof(HandleDismissRecentlyUndone), HandleDismissRecentlyUndone);
         _connection.On<int,string,int>(nameof(HandleJoinGame), HandleJoinGame);
         _connection.On<int>(nameof(HandleSetOrUnsetHost), HandleSetOrUnsetHost);
         _connection.On<int,string>(nameof(HandleObserveGame), HandleObserveGame);
@@ -266,6 +268,39 @@ public class Client : IGameService, IGameClient, IAsyncDisposable
         try
         {
             Game = Game.Undo(untilEventNr);
+            await PerformPostEventTasks();
+        }
+        catch (Exception ex)
+        {
+            Support.Log(ex.ToString());
+        }
+    }
+
+    public async Task HandleRestoreRecentlyUndone()
+    {
+        
+        if (!InGame)
+            return;
+        
+        try
+        {
+            Game = Game.RestoreRecentlyUndone();
+            await PerformPostEventTasks();
+        }
+        catch (Exception ex)
+        {
+            Support.Log(ex.ToString());
+        }
+    }
+
+    public async Task HandleDismissRecentlyUndone()
+    {
+        if (!InGame)
+            return;
+        
+        try
+        {
+            Game = Game.DismissRecentlyUndone();
             await PerformPostEventTasks();
         }
         catch (Exception ex)
@@ -552,6 +587,12 @@ public class Client : IGameService, IGameClient, IAsyncDisposable
         
     public async Task<string> RequestUndo(int untilEventNr) =>
         CurrentSkin.Describe((await Invoke(nameof(IGameHub.RequestUndo), UserToken, GameId, untilEventNr)).Error);
+
+    public async Task<string> RequestRestoreRecentlyUndone() =>
+        CurrentSkin.Describe((await Invoke(nameof(IGameHub.RequestRestoreRecentlyUndone), UserToken, GameId)).Error);
+
+    public async Task<string> RequestDismissRecentlyUndone() =>
+        CurrentSkin.Describe((await Invoke(nameof(IGameHub.RequestDismissRecentlyUndone), UserToken, GameId)).Error);
 
     public async Task<string> SetTimer(int value) =>
         CurrentSkin.Describe((await Invoke(nameof(IGameHub.SetTimer), value)).Error);

--- a/Client/IGameService.cs
+++ b/Client/IGameService.cs
@@ -111,6 +111,8 @@ public interface IGameService
     Task<string> RequestAssignSeats(Dictionary<int, int> seatedPlayers);
     Task<string> RequestSetSkin(string skin);
     Task<string> RequestUndo(int untilEventNr);
+    Task<string> RequestRestoreRecentlyUndone();
+    Task<string> RequestDismissRecentlyUndone();
     Task<string> RequestSetBotSpeed(int speed);
     
     //Game Events

--- a/Client/OtherComponents/MenuComponent.razor
+++ b/Client/OtherComponents/MenuComponent.razor
@@ -171,6 +171,7 @@
 @if (IsVisible(Host))
 {
     <UndoComponent/>
+    <RedoComponent/>
 }
 else if (IsVisible(Help))
 {

--- a/Client/OtherComponents/RedoComponent.razor
+++ b/Client/OtherComponents/RedoComponent.razor
@@ -1,0 +1,35 @@
+@*
+ * Copyright (C) 2020-2025 Ronald Ossendrijver (admin@treachery.online)
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This
+ * program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have
+ * received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
+*@
+@inherits GameComponent
+
+<div class="card p-1 mb-2" style="@(Game.RecentlyUndoneEventCount > 0 ? "" : "display: none;")">
+    <div class="card-header">Recently undone @Game.RecentlyUndoneEventCount event(s)</div>
+    <div class="card-body">
+        <div class="mb-2">
+            @foreach (var evt in Game.RecentlyUndoneEvents)
+            {
+                <div class="small text-muted">@evt.GetShortMessage()?.ToString(Client.CurrentSkin)</div>
+            }
+        </div>
+        <button class="btn btn-success me-2" @onclick="RestoreUndone">Restore</button>
+        <button class="btn btn-secondary" @onclick="DismissUndone">Dismiss</button>
+    </div>
+</div>
+
+@code {
+    private async Task RestoreUndone()
+    {
+        await Client.RequestRestoreRecentlyUndone();
+    }
+
+    private async Task DismissUndone()
+    {
+        await Client.RequestDismissRecentlyUndone();
+    }
+}

--- a/Server/GameHub.cs
+++ b/Server/GameHub.cs
@@ -160,4 +160,5 @@ public partial class GameHub(DbContextOptions<TreacheryContext> dbContextOptions
         result.Position = 0;
         return result;
     }
+    private static string RecentlyUndoneEventNrKey(string gameId) => $"RecentlyUndoneEventNr_{gameId}";
 }

--- a/Server/GameHub_GameManagement.cs
+++ b/Server/GameHub_GameManagement.cs
@@ -482,6 +482,40 @@ public partial class GameHub
         return Success();
     }
 
+    public async Task<VoidResult> RequestRestoreRecentlyUndone(string userToken, string gameId)
+    {
+        if (!AreValid(userToken, gameId, out var user, out var game, out var error))
+            return error!;
+
+        if (!game!.Game.IsHost(user!.Id))
+            return Error(ErrorType.NoHost);
+
+        game.Game = game.Game.RestoreRecentlyUndone();
+        await Clients.Group(gameId).HandleRestoreRecentlyUndone();
+
+        game.LastActivity = DateTimeOffset.Now;
+        await PersistGameIfNeeded(game);
+        ScheduleBotEvent(game);
+        return Success();
+    }
+
+    public async Task<VoidResult> RequestDismissRecentlyUndone(string userToken, string gameId)
+    {
+        if (!AreValid(userToken, gameId, out var user, out var game, out var error))
+            return error!;
+
+        if (!game!.Game.IsHost(user!.Id))
+            return Error(ErrorType.NoHost);
+
+        game.Game = game.Game.DismissRecentlyUndone();
+        await Clients.Group(gameId).HandleDismissRecentlyUndone();
+
+        game.LastActivity = DateTimeOffset.Now;
+        await PersistGameIfNeeded(game);
+        ScheduleBotEvent(game);
+        return Success();
+    }
+
     public async Task<VoidResult> RequestSetBotSpeed(string userToken, string gameId, int speed)
     {
         if (!AreValid(userToken, gameId, out var user, out var game, out var error))

--- a/Shared/Game.cs
+++ b/Shared/Game.cs
@@ -33,6 +33,9 @@ public partial class Game
     public List<Rule> AllRules { get; internal set; } = [];
     public List<GameEvent> History { get; } = [];
     public List<Moment> Moments { get; } = [];
+    public int RecentlyUndoneEventCount { get; set; }
+    public List<GameEvent> RecentlyUndoneEvents { get; } = [];
+    public Game PreviousGameState { get; set; }
     public int CurrentTurn { get; private set; }
     public MainPhase CurrentMainPhase { get; internal set; } = MainPhase.Started;
     public MainPhaseMoment CurrentMoment { get; private set; } = MainPhaseMoment.None;
@@ -137,6 +140,8 @@ public partial class Game
     public Game Undo(int untilEventNr)
     {
         var result = new Game(Version, Participation);
+        result.PreviousGameState = this; // Store the current game state
+
         var maxEventNr = Math.Min(untilEventNr, History.Count);
 
         for (var i = 0; i < maxEventNr; i++)
@@ -144,6 +149,65 @@ public partial class Game
             History[i].Initialize(result);
             History[i].Execute(false, false);
         }
+
+        // Store the recently undone events
+        result.RecentlyUndoneEventCount = History.Count - maxEventNr;
+        for (var i = maxEventNr; i < History.Count; i++)
+        {
+            result.RecentlyUndoneEvents.Add(History[i]);
+        }
+
+        return result;
+    }
+
+    public Game RestoreRecentlyUndone()
+    {
+        if (PreviousGameState != null)
+        {
+            return PreviousGameState;
+        }
+        
+        if (RecentlyUndoneEventCount == 0 || RecentlyUndoneEvents.Count == 0)
+            return this;
+
+        var result = new Game(Version, Participation);
+        
+        // Replay all current history
+        for (var i = 0; i < History.Count; i++)
+        {
+            History[i].Initialize(result);
+            History[i].Execute(false, false);
+        }
+
+        // Add back the recently undone events to history and execute them
+        foreach (var evt in RecentlyUndoneEvents)
+        {
+            evt.Initialize(result);
+            evt.Execute(false, false);
+        }
+
+        // Clear the recently undone events after restoring
+        result.RecentlyUndoneEventCount = 0;
+        result.RecentlyUndoneEvents.Clear();
+
+        return result;
+    }
+
+    public Game DismissRecentlyUndone()
+    {
+        var result = new Game(Version, Participation);
+        var maxEventNr = History.Count;
+
+        for (var i = 0; i < maxEventNr; i++)
+        {
+            History[i].Initialize(result);
+            History[i].Execute(false, false);
+        }
+
+        // Clear the recently undone events and previous game state
+        result.RecentlyUndoneEventCount = 0;
+        result.RecentlyUndoneEvents.Clear();
+        result.PreviousGameState = null;
 
         return result;
     }

--- a/Shared/Model/IGameClient.cs
+++ b/Shared/Model/IGameClient.cs
@@ -19,6 +19,8 @@ public interface IGameClient
     Task HandleSetTimer(int value);
     Task HandleSetSkin(string skin);
     Task HandleUndo(int untilEventNr);
+    Task HandleRestoreRecentlyUndone();
+    Task HandleDismissRecentlyUndone();
     Task HandleUpdateSettings(GameSettings settings);
     Task HandleJoinGame(int userId, string userName, int seat);
     Task HandleSetOrUnsetHost(int userId);

--- a/Shared/Model/IGameHub.cs
+++ b/Shared/Model/IGameHub.cs
@@ -29,6 +29,8 @@ public interface IGameHub
     Task<VoidResult> RequestLoadGame(string userToken, string hashedPassword, string state, string skin);
     Task<VoidResult> RequestSetSkin(string userToken, string gameId, string skin);
     Task<VoidResult> RequestUndo(string userToken, string gameId, int untilEventNr);
+    Task<VoidResult> RequestRestoreRecentlyUndone(string userToken, string gameId);
+    Task<VoidResult> RequestDismissRecentlyUndone(string userToken, string gameId);
     Task<Result<GameInitInfo>> RequestGameState(string userToken, string gameId);
     Task<VoidResult> RequestSetBotSpeed(string userToken, string gameId, int speed);
     Task<Result<ServerStatus>> RequestHeartbeat(string userToken, GameListScope scope);


### PR DESCRIPTION
Introduce redo support for recently undone events:
- Added RedoComponent UI and show it in the menu for hosts.
- Extend the client with handlers and service calls (Restore/DismissRecentlyUndone) and register SignalR callbacks.
- Added hub methods RequestRestoreRecentlyUndone and RequestDismissRecentlyUndone on the server 
-- Validates host permissions
-- Updates the Game via new Game.RestoreRecentlyUndone / Game.DismissRecentlyUndone methods 
-- Broadcast updates to the group, persist state and schedule bot events. 
-- Updates the Game model to track RecentlyUndoneEventCount, RecentlyUndoneEvents and PreviousGameState
- Modified Undo to record the previous state and the undone events.